### PR TITLE
Wrap raw TypeError/RuntimeError in GMDCommandError

### DIFF
--- a/global_macro_data/gmd.py
+++ b/global_macro_data/gmd.py
@@ -139,6 +139,11 @@ def _tokens(value: Union[str, Sequence[str], None]) -> List[str]:
     if isinstance(value, str):
         bits = value.replace(",", " ").split()
         return [bit.strip() for bit in bits if bit.strip()]
+    if not isinstance(value, (list, tuple)):
+        raise GMDCommandError(
+            f"Expected a string or sequence of strings, got {type(value).__name__}.",
+            code=198,
+        )
     out: List[str] = []
     for item in value:
         if isinstance(item, str):
@@ -330,13 +335,16 @@ def _strip_source_prefix_cols(df: pd.DataFrame, source: str) -> List[str]:
 def get_available_versions() -> List[str]:
     try:
         return _versions_df()["versions"].astype(str).tolist()
-    except RuntimeError:
+    except RuntimeError as exc:
         versions = _cache_versions()
         if versions:
             return versions
         if _default_local_gmd_path() is not None:
             return ["local"]
-        raise
+        raise GMDCommandError(
+            "Unable to fetch the list of available GMD versions. "
+            "Check your internet connection or raise an issue."
+        ) from exc
 
 
 def get_current_version() -> str:


### PR DESCRIPTION
Tracked upstream at [Global-Macro-Database-Internal#414](https://github.com/KMueller-Lab/Global-Macro-Database-Internal/issues/414). Same filter as the recent Stata and R PRs: fix actual bugs, skip nice-to-haves.

## Bugs

Both failure paths leaked internal exception types to users instead of the package's own `GMDCommandError`.

### 1. `gmd(country=840)` leaked `TypeError: 'int' object is not iterable`

Root cause: [`_tokens()`](https://github.com/KMueller-Lab/Global-Macro-Database-Python/blob/main/global_macro_data/gmd.py#L136) did `for item in value:` with no type guard. Any scalar non-string (int, float, etc.) tripped Python's iteration protocol, not the package's own error surface. Same class of leak for `variables=840`, `variables=1.5`, etc.

### 2. `get_available_versions()` leaked `RuntimeError` when both mirrors were unreachable

[`gmd.py:333-344`](https://github.com/KMueller-Lab/Global-Macro-Database-Python/blob/main/global_macro_data/gmd.py#L333-L344) caught the internal `RuntimeError` from `_fetch_from`, checked the on-disk cache and a local `.dta` fallback, and then bare-`raise`'d the internal error back to the user.

## Fix

Two small changes:

1. `_tokens()` now rejects non-str / non-list / non-tuple inputs with `GMDCommandError(code=198)` and a message naming the actual type.
2. The terminal `raise` in `get_available_versions()` becomes a `raise GMDCommandError(...) from exc` with a message that tells the user what probably went wrong (no internet / transient outage).

## Verified (live)

```python
>>> gmd(country=840)
GMDCommandError: Expected a string or sequence of strings, got int.
>>> gmd(country=840.5)
GMDCommandError: Expected a string or sequence of strings, got float.
>>> gmd(variables=840)
GMDCommandError: Expected a string or sequence of strings, got int.

# Regressions:
>>> gmd(country="USA", variables="rGDP")          # DataFrame
>>> gmd(country=["USA","GBR"], variables="rGDP")  # DataFrame
>>> gmd(country=None, variables="rGDP")           # DataFrame
>>> gmd(country=["USA", 840], variables="rGDP")   # already caught; unchanged behavior

# Offline path (both mirrors failing, no local cache):
>>> get_available_versions()
GMDCommandError: Unable to fetch the list of available GMD versions.
                 Check your internet connection or raise an issue.

# Online sanity:
>>> get_available_versions()                       # list of versions
```

## Out of scope

Other items in #414 are UX/consistency rather than correctness bugs and kept for separate PRs:

- `raw`/`fast`/`iso` truthy-string coercion (`raw="no"` still loads raw data) — same class as the Stata `fast()` UX wart, classified as "nice-to-have" in the Stata review.
- Whole-file download / no retry-backoff / no checksum / unversioned cache — design-level improvements.
- `start_year` / `end_year` — not implementing per maintainer preference.

Also note: the listed-but-404 versions on S3 (`2025_01/03/05/06/08`) are a release-pipeline issue and not fixable here.