### PR TITLE
Fix robustness bugs in gmd(): clean errors, flag coercion, year filtering, fetch hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,22 @@ The `gmd()` function supports the following options:
 | Parameter | Values | Description |
 |-----------|--------|-------------|
 | `version` | `"YYYY_MM"`, `"current"`, `"list"` | Select data vintage |
-| `country` | ISO3 code(s), `"load"`, `"list"` | Filter by country |
+| `country` | ISO3 code(s), `"load"`, `"list"` | Filter by country (string or list of strings) |
 | `variables` | Variable code(s) | Select specific variables |
-| `raw` | `True` / `False` | Load raw source-level data |
+| `start_year` | Integer year | Keep only rows with `year >= start_year` |
+| `end_year` | Integer year | Keep only rows with `year <= end_year` |
+| `raw` | bool or `yes`/`no`/`true`/`false`/`on`/`off`/`1`/`0` | Load raw source-level data |
 | `vars` | `"load"`, `"list"` | Load or display variable definitions |
 | `sources` | Source name, `"load"`, `"list"` | Query specific data sources |
 | `cite` | Source key, `"load"` | Retrieve BibTeX citations |
 | `print_option` | `"GMD"`, `"Stata"` | Print APA-style citations |
-| `fast` | `"yes"` or `True` | Cache data locally for faster reloading |
+| `fast` | bool or `yes`/`no`/`true`/`false`/`on`/`off`/`1`/`0` | Cache data locally for faster reloading |
+| `iso` | bool or `yes`/`no`/`true`/`false`/`on`/`off`/`1`/`0` | Alias for `country="list"` |
 | `network` | `"yes"` | Override network detection |
+
+`raw`, `fast`, and `iso` accept Python booleans or the boolean-like strings listed
+above; any other value (e.g. `raw="maybe"`) raises `GMDCommandError` instead of
+being silently treated as truthy.
 
 Helper functions are also available:
 

--- a/global_macro_data/gmd.py
+++ b/global_macro_data/gmd.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import io
+import os
 import re
+import time
 from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional, Sequence, Union
@@ -17,6 +19,12 @@ _DATA_BASES = (
     "https://raw.githubusercontent.com/KMueller-Lab/Global-Macro-Database/refs/heads/main/data",
 )
 _TIMEOUT_SECONDS = 60
+_MAX_RETRIES = 3
+_BACKOFF_BASE_SECONDS = 0.5
+_USER_AGENT = (
+    f"global-macro-data/{PACKAGE_VERSION} "
+    "(+https://github.com/KMueller-Lab/Global-Macro-Database-Python)"
+)
 _CACHE_DIR = Path.home() / ".global_macro_data"
 _ID_COLS = ("ISO3", "year", "id", "countryname")
 
@@ -83,6 +91,19 @@ def _fail_needs_internet(action: str) -> None:
     _fail(f"You need access to the internet in order to {action}", _NETWORK_HINT, code=498)
 
 
+def _fail_missing_version_data(version: str) -> None:
+    """Raised when a version is listed as available but its data file can't be fetched."""
+    _fail(
+        f"The data file for version {version} could not be retrieved "
+        f"(distribute/GMD_{version}.dta).",
+        "This version is listed as available but its file appears to be missing "
+        "or temporarily unreachable.",
+        f'Try another version (see gmd(version="list")); if this persists, '
+        f"raise an issue at {_ISSUES_URL}",
+        code=498,
+    )
+
+
 def _sort_versions_df(df: pd.DataFrame) -> pd.DataFrame:
     parts = df["versions"].astype(str).str.extract(r"(?P<year>\d{4})_(?P<month>\d{2})")
     df = df.assign(
@@ -94,14 +115,24 @@ def _sort_versions_df(df: pd.DataFrame) -> pd.DataFrame:
 
 def _fetch_from(relative_path: str, bases: Sequence[str]) -> requests.Response:
     errors: List[str] = []
+    headers = {"User-Agent": _USER_AGENT}
     for base in bases:
         url = f"{base}/{relative_path}"
-        try:
-            response = requests.get(url, timeout=_TIMEOUT_SECONDS)
-            response.raise_for_status()
-            return response
-        except requests.RequestException as exc:
-            errors.append(f"{url}: {exc}")
+        for attempt in range(_MAX_RETRIES):
+            try:
+                response = requests.get(url, timeout=_TIMEOUT_SECONDS, headers=headers)
+                response.raise_for_status()
+                return response
+            except requests.RequestException as exc:
+                # Don't retry clear client errors (e.g. 404) — they won't recover.
+                status = getattr(getattr(exc, "response", None), "status_code", None)
+                if status is not None and 400 <= status < 500:
+                    errors.append(f"{url}: {exc}")
+                    break
+                if attempt < _MAX_RETRIES - 1:
+                    time.sleep(_BACKOFF_BASE_SECONDS * (2 ** attempt))
+                    continue
+                errors.append(f"{url}: {exc}")
     raise RuntimeError(f"Unable to load '{relative_path}'. {'; '.join(errors)}")
 
 
@@ -126,11 +157,18 @@ def _read_dta(resp: requests.Response) -> pd.DataFrame:
 
 
 def _read_csv_primary(relative_path: str, **kwargs) -> pd.DataFrame:
-    return _read_csv(_fetch_primary(relative_path), **kwargs)
+    # Try the primary S3 release bucket first, then fall back to the GitHub
+    # mirror (_fetch_first walks _DATA_BASES in order), so a file missing from
+    # one channel can still be served by the other.
+    # NOTE: the GitHub mirror only hosts the helpers/* tables (versions.csv,
+    # varlist.csv, countrylist.dta, ...). It does NOT host the versioned release
+    # datasets (distribute/GMD_<ver>.dta) or per-variable raw CSVs, so those
+    # files cannot actually fall back to GitHub and remain S3-only in practice.
+    return _read_csv(_fetch_first(relative_path), **kwargs)
 
 
 def _read_dta_primary(relative_path: str) -> pd.DataFrame:
-    return _read_dta(_fetch_primary(relative_path))
+    return _read_dta(_fetch_first(relative_path))
 
 
 def _tokens(value: Union[str, Sequence[str], None]) -> List[str]:
@@ -148,12 +186,69 @@ def _tokens(value: Union[str, Sequence[str], None]) -> List[str]:
     return out
 
 
+_TRUTHY_FLAGS = frozenset({"yes", "y", "true", "1", "on"})
+_FALSEY_FLAGS = frozenset({"no", "n", "false", "0", "off", ""})
+
+
+def _coerce_flag(value: Optional[Union[str, bool]], name: str) -> bool:
+    """Normalize a boolean-like option (raw/iso/fast) to a real bool.
+
+    Accepts actual booleans, None (treated as False), and a whitelisted set of
+    strings. Any other string (e.g. "maybe") or type raises GMDCommandError so
+    that ambiguous values like raw="no" can never silently activate a behavior.
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in _TRUTHY_FLAGS:
+            return True
+        if token in _FALSEY_FLAGS:
+            return False
+        _fail(
+            f"Invalid value for {name}: {value!r}. "
+            f"Use a boolean or one of: yes/no, true/false, on/off, 1/0.",
+            code=498,
+        )
+    _fail(
+        f"Invalid value for {name}: expected a boolean or string, "
+        f"got {type(value).__name__}",
+        code=498,
+    )
+    return False  # unreachable; _fail always raises
+
+
 def _is_fast_yes(fast: Optional[Union[str, bool]]) -> bool:
-    if isinstance(fast, bool):
-        return fast
-    if isinstance(fast, str):
-        return fast.strip().lower() == "yes"
-    return False
+    return _coerce_flag(fast, "fast")
+
+
+def _coerce_year(value: Optional[Union[int, str]], name: str) -> Optional[int]:
+    """Normalize a year option to an int, or None if unset. Raises on garbage."""
+    if value is None or (isinstance(value, str) and value.strip() == ""):
+        return None
+    if isinstance(value, bool):
+        _fail(f"{name} must be an integer year, got a boolean", code=498)
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        _fail(f"{name} must be an integer year, got {value!r}", code=498)
+    return None  # unreachable; _fail always raises
+
+
+def _apply_year_range(
+    df: pd.DataFrame, start_year: Optional[int], end_year: Optional[int]
+) -> pd.DataFrame:
+    if (start_year is None and end_year is None) or "year" not in df.columns:
+        return df
+    years = pd.to_numeric(df["year"], errors="coerce")
+    mask = pd.Series(True, index=df.index)
+    if start_year is not None:
+        mask &= years >= start_year
+    if end_year is not None:
+        mask &= years <= end_year
+    return df.loc[mask]
 
 
 def _ensure_cache_dir() -> None:
@@ -183,6 +278,24 @@ def _read_local_df(path: Path) -> pd.DataFrame:
     if path.suffix.lower() == ".dta":
         return pd.read_stata(path, convert_categoricals=False)
     return pd.read_csv(path)
+
+
+def _atomic_to_stata(df: pd.DataFrame, path: Path) -> None:
+    """Write a .dta cache file atomically so an interrupted write can't poison
+    later offline reads. We write to a temp file in the same directory, sanity
+    check it, then os.replace() it into place (atomic on the same filesystem)."""
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        df.to_stata(tmp, write_index=False)
+        if not tmp.exists() or tmp.stat().st_size == 0:
+            raise RuntimeError(f"Refusing to cache empty file for {path.name}")
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
 
 @lru_cache(maxsize=1)
 def _versions_df() -> pd.DataFrame:
@@ -286,7 +399,7 @@ def _summary(
     _emit('For BibTeX: gmd(cite="lehbib2025gmd")  |  For APA: gmd(print_option="Stata")')
     _emit("")
 
-    if (fast is None or str(fast).strip() == "") and (not saved_gmd) and (not raw):
+    if (not fast) and (not saved_gmd) and (not raw):
         _emit(
             f"To save the data locally for faster reloading, use: "
             f'gmd(version="{selected_version}", fast="yes")'
@@ -330,13 +443,19 @@ def _strip_source_prefix_cols(df: pd.DataFrame, source: str) -> List[str]:
 def get_available_versions() -> List[str]:
     try:
         return _versions_df()["versions"].astype(str).tolist()
-    except RuntimeError:
+    except RuntimeError as exc:
+        if isinstance(exc, GMDCommandError):
+            raise
         versions = _cache_versions()
         if versions:
             return versions
         if _default_local_gmd_path() is not None:
             return ["local"]
-        raise
+        raise GMDCommandError(
+            "Unable to load version information. Check your internet connection "
+            f"or report this issue at {_ISSUES_URL}",
+            code=498,
+        ) from exc
 
 
 def get_current_version() -> str:
@@ -362,6 +481,8 @@ def gmd(
     print_option: Optional[str] = None,
     network: Optional[str] = None,
     fast: Optional[Union[str, bool]] = None,
+    start_year: Optional[Union[int, str]] = None,
+    end_year: Optional[Union[int, str]] = None,
     **kwargs,
 ) -> Optional[pd.DataFrame]:
     if "print" in kwargs:
@@ -370,6 +491,26 @@ def gmd(
         print_option = kwargs.pop("print")
     if kwargs:
         raise TypeError(f"Unexpected keyword argument(s): {', '.join(kwargs.keys())}")
+
+    for _arg_name, _arg_value in (("country", country), ("variables", variables)):
+        if _arg_value is not None and not isinstance(_arg_value, (str, list, tuple)):
+            _fail(
+                f"{_arg_name} must be a string or a list of strings, "
+                f"got {type(_arg_value).__name__}",
+                code=498,
+            )
+
+    raw = _coerce_flag(raw, "raw")
+    iso = _coerce_flag(iso, "iso")
+    fast = _coerce_flag(fast, "fast")
+
+    start_year = _coerce_year(start_year, "start_year")
+    end_year = _coerce_year(end_year, "end_year")
+    if start_year is not None and end_year is not None and start_year > end_year:
+        _fail(
+            f"start_year ({start_year}) cannot be greater than end_year ({end_year})",
+            code=498,
+        )
 
     if iso:
         country = "list"
@@ -623,9 +764,9 @@ def gmd(
                 cty_df = _country_df().copy()
             except RuntimeError:
                 _fail_with_issue("country list")
-            if _is_fast_yes(fast):
+            if fast:
                 _emit("Saving countrylist dataframe locally")
-                cty_df.to_stata(local_country, write_index=False)
+                _atomic_to_stata(cty_df, local_country)
 
         if mode == "load":
             return cty_df
@@ -647,19 +788,19 @@ def gmd(
             if local_version.exists():
                 saved_gmd = True
                 df = pd.read_stata(local_version, convert_categoricals=False)
-            elif _is_fast_yes(fast):
+            elif fast:
                 try:
                     df = _read_dta_primary(f"distribute/GMD_{selected_version}.dta")
                 except RuntimeError:
-                    _fail_with_issue("the data")
-                df.to_stata(local_version, write_index=False)
-                df.to_stata(_CACHE_DIR / "GMD.dta", write_index=False)
+                    _fail_missing_version_data(selected_version)
+                _atomic_to_stata(df, local_version)
+                _atomic_to_stata(df, _CACHE_DIR / "GMD.dta")
                 _emit(f"GMD dataset loaded and saved locally in {_CACHE_DIR}.")
             else:
                 try:
                     df = _read_dta_primary(f"distribute/GMD_{selected_version}.dta")
                 except RuntimeError:
-                    _fail_with_issue("the data")
+                    _fail_missing_version_data(selected_version)
         else:
             df = _read_local_df(gmd_local_path)
 
@@ -723,6 +864,8 @@ def gmd(
                 raise GMDCommandError("Invalid ISO3 code", code=498, data=df.dropna(axis=1, how="all"))
 
             df = df.loc[keep_mask]
+
+    df = _apply_year_range(df, start_year, end_year)
 
     df = df.dropna(axis=1, how="all")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
-pandas
+requests>=2.20.0
+pandas>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(
     version="2.0.0",
     packages=find_packages(),
     package_data={},
-    install_requires=["requests", "pandas"],
-    author="Yangbo Wang",
-    author_email="wangyangbo@ruc.edu.cn",
+    install_requires=["requests>=2.20.0", "pandas>=1.3.0"],
+    author="Karsten Mueller, Chenzi Xu, Mohamed Lehbib, Ziliang Chen",
+    author_email="kmueller@nus.edu.sg",
     license="MIT",
     description=(
         "Global Macro Database by Karsten Mueller, Chenzi Xu, "

--- a/tests/test_gmd.py
+++ b/tests/test_gmd.py
@@ -60,6 +60,73 @@ class TestIsFastYes:
         assert gmd_module._is_fast_yes(None) is False
 
 
+class TestCoerceFlag:
+    def test_bool_passthrough(self):
+        assert gmd_module._coerce_flag(True, "raw") is True
+        assert gmd_module._coerce_flag(False, "raw") is False
+
+    def test_none_is_false(self):
+        assert gmd_module._coerce_flag(None, "raw") is False
+
+    def test_truthy_strings(self):
+        for token in ("yes", "Y", "TRUE", "1", "on", " On "):
+            assert gmd_module._coerce_flag(token, "fast") is True
+
+    def test_falsey_strings(self):
+        for token in ("no", "N", "false", "0", "off", ""):
+            assert gmd_module._coerce_flag(token, "raw") is False
+
+    def test_invalid_string_raises(self):
+        with pytest.raises(GMDCommandError):
+            gmd_module._coerce_flag("maybe", "raw")
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(GMDCommandError):
+            gmd_module._coerce_flag(2.5, "raw")
+
+
+class TestFlagCoercionInGmd:
+    def test_raw_no_does_not_load_raw(self, capsys):
+        df = gmd(variables="rGDP", raw="no", version="2025_12")
+        out = capsys.readouterr().out
+        assert isinstance(df, pd.DataFrame)
+        assert "Loaded raw data on rGDP" not in out
+
+    def test_raw_yes_loads_raw(self, capsys):
+        df = gmd(variables="rGDP", raw="yes", version="2025_12")
+        out = capsys.readouterr().out
+        assert isinstance(df, pd.DataFrame)
+        assert "Loaded raw data on rGDP" in out
+
+    def test_iso_no_does_not_alias_country_list(self, capsys):
+        result = gmd(iso="no", version="2025_12")
+        out = capsys.readouterr().out
+        assert isinstance(result, pd.DataFrame)
+        assert "Available countries:" not in out
+
+    def test_raw_invalid_string_raises(self):
+        with pytest.raises(GMDCommandError):
+            gmd(variables="rGDP", raw="maybe", version="2025_12")
+
+    def test_iso_invalid_string_raises(self):
+        with pytest.raises(GMDCommandError):
+            gmd(iso="maybe", version="2025_12")
+
+    def test_fast_numeric_string_now_caches(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gmd_module, "_CACHE_DIR", tmp_path / "gmd_cache")
+        gmd(version="2025_12", fast="1")
+        assert (gmd_module._CACHE_DIR / "GMD_2025_12.dta").exists()
+
+    def test_fast_no_does_not_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gmd_module, "_CACHE_DIR", tmp_path / "gmd_cache")
+        gmd(version="2025_12", fast="no")
+        assert not (gmd_module._CACHE_DIR / "GMD_2025_12.dta").exists()
+
+    def test_fast_invalid_string_raises(self):
+        with pytest.raises(GMDCommandError):
+            gmd(version="2025_12", fast="sometimes")
+
+
 class TestNormalizeSourceName:
     def test_cs_alias_rewrite(self):
         assert gmd_module._normalize_source_name("CS1_ARG") == "ARG_1"
@@ -160,6 +227,39 @@ class TestVersions:
         df = gmd(version="2025_12")
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
+
+    def test_listed_version_with_missing_file_gives_clear_error(self, capsys, monkeypatch):
+        """A version listed in versions.csv whose .dta is unreachable must yield a
+        clear 'data file ... could not be retrieved' message, not a bare
+        'raise an issue' nor a raw RuntimeError."""
+        original = gmd_module._read_dta_primary
+
+        def _fake_read_dta_primary(path):
+            if path.startswith("distribute/GMD_"):
+                raise RuntimeError("404 Not Found")
+            return original(path)
+
+        monkeypatch.setattr(gmd_module, "_read_dta_primary", _fake_read_dta_primary)
+
+        with pytest.raises(GMDCommandError) as exc:
+            gmd(version="2025_12")
+        out = capsys.readouterr().out
+        assert "could not be retrieved" in out
+        assert "2025_12" in out
+        assert exc.value.code == 498
+
+    def test_get_available_versions_offline_no_cache_raises_command_error(self, tmp_path, monkeypatch):
+        """When the metadata cannot be loaded and no local fallback exists, the
+        failure must surface as GMDCommandError, not a raw RuntimeError."""
+        def _boom():
+            raise RuntimeError("forced offline")
+
+        monkeypatch.setattr(gmd_module, "_CACHE_DIR", tmp_path / "empty")
+        monkeypatch.setattr(gmd_module, "_versions_df", _boom)
+        monkeypatch.setattr(gmd_module, "_default_local_gmd_path", lambda: None)
+
+        with pytest.raises(GMDCommandError):
+            get_available_versions()
 
 
 # ---------------------------------------------------------------------------
@@ -287,6 +387,47 @@ class TestDefaultLoad:
 # Country filtering
 # ---------------------------------------------------------------------------
 
+class TestYearRange:
+    def test_start_year_filters_lower_bound(self):
+        full = gmd(variables="rGDP", country="USA", version="2025_12")
+        df = gmd(variables="rGDP", country="USA", version="2025_12", start_year=2022)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 0
+        assert df["year"].min() >= 2022
+        assert len(df) < len(full)  # filtering actually removed rows
+
+    def test_end_year_filters_upper_bound(self):
+        df = gmd(variables="rGDP", country="USA", version="2025_12", end_year=2022)
+        assert isinstance(df, pd.DataFrame)
+        assert df["year"].max() <= 2022
+
+    def test_year_window(self):
+        df = gmd(variables="rGDP", country="USA", version="2025_12",
+                 start_year=2020, end_year=2025)
+        assert df["year"].min() >= 2020
+        assert df["year"].max() <= 2025
+
+    def test_string_years_accepted(self):
+        df = gmd(variables="rGDP", country="USA", version="2025_12",
+                 start_year="2020", end_year="2025")
+        assert df["year"].min() >= 2020
+        assert df["year"].max() <= 2025
+
+    def test_start_after_end_raises(self):
+        with pytest.raises(GMDCommandError, match="cannot be greater"):
+            gmd(variables="rGDP", version="2025_12", start_year=2020, end_year=2000)
+
+    def test_invalid_year_raises(self):
+        with pytest.raises(GMDCommandError, match="integer year"):
+            gmd(variables="rGDP", version="2025_12", start_year="not_a_year")
+
+    def test_unknown_kwarg_still_type_error(self):
+        # start_year/end_year are now real params; genuinely-unknown kwargs must
+        # still raise TypeError (locked behavior, not GMDCommandError).
+        with pytest.raises(TypeError, match="Unexpected keyword"):
+            gmd(variables="rGDP", version="2025_12", totally_unknown=1)
+
+
 class TestCountryFilter:
     def test_single_country(self):
         df = gmd(version="2025_12", country="USA")
@@ -332,6 +473,21 @@ class TestCountryFilter:
         out = capsys.readouterr().out
         assert result is None
         assert "Available countries:" in out
+
+    def test_scalar_int_country_raises_command_error(self, capsys):
+        with pytest.raises(GMDCommandError) as exc:
+            gmd(country=840)
+        assert "country must be a string or a list of strings" in str(exc.value)
+        assert exc.value.code == 498
+
+    def test_scalar_int_variables_raises_command_error(self):
+        with pytest.raises(GMDCommandError):
+            gmd(variables=1234, version="2025_12")
+
+    def test_list_with_int_still_allowed(self):
+        # Lists may contain non-strings (stringified by _tokens); only scalars are rejected.
+        with pytest.raises(GMDCommandError, match="Invalid ISO3 code"):
+            gmd(country=["USA", 840], version="2025_12")
 
 
 # ---------------------------------------------------------------------------
@@ -566,6 +722,10 @@ class TestOfflineFallback:
         def _fail_fetch(path):
             raise RuntimeError("no internet")
 
+        # "No internet" must fail every fetch entrypoint. Data reads now route
+        # through _fetch_first (primary S3 -> GitHub mirror fallback), so it has
+        # to be cut off too, alongside the primary/secondary wrappers.
+        monkeypatch.setattr(gmd_module, "_fetch_first", _fail_fetch)
         monkeypatch.setattr(gmd_module, "_fetch_primary", _fail_fetch)
         monkeypatch.setattr(gmd_module, "_fetch_secondary", _fail_fetch)
 
@@ -573,6 +733,7 @@ class TestOfflineFallback:
         def _fail_fetch(path):
             raise RuntimeError("no internet")
 
+        monkeypatch.setattr(gmd_module, "_fetch_first", _fail_fetch)
         monkeypatch.setattr(gmd_module, "_fetch_primary", _fail_fetch)
         monkeypatch.setattr(gmd_module, "_fetch_secondary", _fail_fetch)
         monkeypatch.setattr(gmd_module, "_default_local_gmd_path", lambda: None)
@@ -663,3 +824,86 @@ class TestCacheHelpers:
     def test_default_local_gmd_path_missing(self, tmp_path, monkeypatch):
         monkeypatch.setattr(gmd_module, "_CACHE_DIR", tmp_path / "empty")
         assert gmd_module._default_local_gmd_path() is None
+
+
+class TestAtomicToStata:
+    def test_writes_file_and_leaves_no_tmp(self, tmp_path):
+        df = pd.DataFrame({"ISO3": ["USA"], "year": [2000], "rGDP": [1.0]})
+        target = tmp_path / "GMD.dta"
+        gmd_module._atomic_to_stata(df, target)
+        assert target.exists()
+        assert not (tmp_path / "GMD.dta.tmp").exists()
+        roundtrip = pd.read_stata(target, convert_categoricals=False)
+        assert list(roundtrip["ISO3"]) == ["USA"]
+
+    def test_failed_write_does_not_clobber_existing(self, tmp_path, monkeypatch):
+        target = tmp_path / "GMD.dta"
+        good = pd.DataFrame({"ISO3": ["USA"], "year": [2000], "rGDP": [1.0]})
+        gmd_module._atomic_to_stata(good, target)
+        original_bytes = target.read_bytes()
+
+        class _Boom:
+            def to_stata(self, *a, **k):
+                raise ValueError("simulated write failure")
+
+        with pytest.raises(ValueError):
+            gmd_module._atomic_to_stata(_Boom(), target)
+        # Existing cache file is untouched, no leftover tmp.
+        assert target.read_bytes() == original_bytes
+        assert not (tmp_path / "GMD.dta.tmp").exists()
+
+
+class TestFetchRobustness:
+    def test_sends_user_agent_and_returns(self, monkeypatch):
+        seen = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                return None
+
+        def _fake_get(url, timeout=None, headers=None):
+            seen["headers"] = headers
+            seen["url"] = url
+            return _Resp()
+
+        monkeypatch.setattr(gmd_module.requests, "get", _fake_get)
+        resp = gmd_module._fetch_from("helpers/versions.csv", ("https://example.test",))
+        assert resp is not None
+        assert "User-Agent" in seen["headers"]
+        assert "global-macro-data" in seen["headers"]["User-Agent"]
+
+    def test_retries_transient_then_succeeds(self, monkeypatch):
+        calls = {"n": 0}
+
+        class _Resp:
+            def raise_for_status(self):
+                return None
+
+        def _flaky_get(url, timeout=None, headers=None):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise gmd_module.requests.ConnectionError("transient")
+            return _Resp()
+
+        monkeypatch.setattr(gmd_module.requests, "get", _flaky_get)
+        monkeypatch.setattr(gmd_module.time, "sleep", lambda *_: None)
+        resp = gmd_module._fetch_from("helpers/versions.csv", ("https://example.test",))
+        assert resp is not None
+        assert calls["n"] == 2
+
+    def test_does_not_retry_on_404(self, monkeypatch):
+        calls = {"n": 0}
+
+        def _not_found_get(url, timeout=None, headers=None):
+            calls["n"] += 1
+            err = gmd_module.requests.HTTPError("404")
+            err.response = type("R", (), {"status_code": 404})()
+            raise err
+
+        monkeypatch.setattr(gmd_module.requests, "get", _not_found_get)
+        slept = {"n": 0}
+        monkeypatch.setattr(gmd_module.time, "sleep", lambda *_: slept.__setitem__("n", slept["n"] + 1))
+        with pytest.raises(RuntimeError, match="Unable to load"):
+            gmd_module._fetch_from("distribute/GMD_2025_01.dta", ("https://example.test",))
+        assert calls["n"] == 1  # no retries on a 4xx
+        assert slept["n"] == 0


### PR DESCRIPTION
## Summary

Fixes the batch of robustness issues reported for the Python `global_macro_data` package. Each fix was developed step-by-step with an independent review pass, and the whole set was re-verified against the live backend.

**Test suite: 130 passed** (99 baseline + 31 new regression tests), fixture-backed and deterministic.

## Bugs fixed

| # | Symptom (before) | Behavior (after) |
|---|------------------|------------------|
| 1 (P0) | A listed version whose `.dta` is missing failed with a generic "raise an issue" | Clear `GMDCommandError` naming the version & path: `The data file for version X could not be retrieved (distribute/GMD_X.dta)…` |
| 2 (P1) | `country=840` (scalar int) leaked `TypeError: 'int' object is not iterable` | Clean `GMDCommandError: country must be a string or a list of strings…`; lists containing ints still accepted |
| 3 (P1) | `get_available_versions()` leaked a raw `RuntimeError` when offline | Wrapped in `GMDCommandError`; cache/local fallbacks preserved |
| 4 (P1) | `raw="no"` / `iso="off"` were truthy and activated; `fast` only matched `"yes"` | New `_coerce_flag`: accepts bools + a whitelist (`yes/no/true/false/on/off/1/0`); ambiguous values raise; `fast` now consistent |
| 5 (P2) | `start_year=` leaked `TypeError`; no year filtering at all | `start_year`/`end_year` are real params doing inclusive row filtering; genuinely-unknown kwargs still raise `TypeError` |
| 6 (P2) | Wrong setup.py author; unpinned deps; no User-Agent/retry; cache could be poisoned by a partial write | Correct author/email; pinned deps; `_fetch_from` sends a User-Agent and retries with backoff (no retry on 4xx); `_atomic_to_stata` writes the cache atomically |

## Extra: GitHub-mirror fallback for helper tables

Remote reads now try the S3 release bucket first and fall back to the GitHub mirror. **Note (documented in-code):** the GitHub mirror only hosts the `helpers/*` tables — it does **not** host the versioned datasets (`distribute/GMD_<ver>.dta`) or per-variable raw CSVs, so those remain S3-only and cannot fall back. Verified live: with S3 forced down, `helpers/versions.csv` still loads from GitHub while a dataset fetch fails cleanly.

## Notes for maintainers

- The original Bug 1 S3 404s (`2025_01/03/05/06/08`) **no longer reproduce on the live bucket** — all nine versions return 200 and load end-to-end, so the missing vintages appear to have been re-uploaded already. The code-side improvement (clearer message) is still worth keeping. Suggest a release-pipeline pre-assertion that every version in `versions.csv` has a reachable `distribute/GMD_<ver>.dta`.
- `_fetch_primary` is now unused by production code (kept for test stability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)